### PR TITLE
Return upload process

### DIFF
--- a/django_vimeo/storage.py
+++ b/django_vimeo/storage.py
@@ -149,4 +149,4 @@ class VimeoFileStorage(Storage):
         upload_options = self.upload_options
         if upload_options:
             kwargs['data'] = upload_options
-        self.client.upload(file_path, **kwargs)
+        return self.client.upload(file_path, **kwargs)


### PR DESCRIPTION
it is necessary to get the video `uri` at the end of the upload process.